### PR TITLE
Merge trending whitelist with scanner results

### DIFF
--- a/autonomous_trader_scanner_trailing/config/config.json
+++ b/autonomous_trader_scanner_trailing/config/config.json
@@ -13,7 +13,8 @@
     "refresh_minutes": 90,
     "min_24h_usdt_volume": 10000000,
     "min_atr_pct": 0.8,
-    "max_symbols": 20
+    "max_symbols": 20,
+    "max_trending_symbols": 10
   },
 
   "risk": {

--- a/autonomous_trader_scanner_trailing/utils/scanner_helper.py
+++ b/autonomous_trader_scanner_trailing/utils/scanner_helper.py
@@ -1,8 +1,12 @@
 # utils/scanner_helper.py
 import os
+import json
 from typing import List, Tuple
 from utils.data_fetchers import save_runtime_whitelist
 from utils.market_data_cryptofeed import get_global_hub
+
+BASE = os.path.dirname(os.path.dirname(__file__))
+TREND_PATH = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
 
 def _to_quote_vol_usd(price: float, base_vol: float) -> float:
     if price is None or base_vol is None:
@@ -28,6 +32,22 @@ def run_scanner(cfg) -> List[str]:
     min_qv = float(sc.get("min_24h_usdt_volume", 10_000_000))
     min_atr_pct = float(sc.get("min_atr_pct", 0.8))
     top_n = int(sc.get("max_symbols", 20))
+    trend_n = int(sc.get("max_trending_symbols", top_n // 2))
+
+    trending: List[str] = []
+    if os.path.exists(TREND_PATH):
+        try:
+            with open(TREND_PATH, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    for s in data:
+                        if isinstance(s, str):
+                            s = s.strip().upper()
+                            if s and s not in trending:
+                                trending.append(s)
+        except Exception:
+            pass
+    trending = trending[:trend_n]
 
     rows: List[Tuple[str, float, float]] = []  # (symbol, qv_usd, atr_pct)
     for sym in hub.list_symbols():
@@ -51,11 +71,26 @@ def run_scanner(cfg) -> List[str]:
             if qv >= min_qv:
                 fallback.append((sym, qv))
         fallback.sort(key=lambda x: x[1], reverse=True)
-        out_syms = [s for s,_ in fallback[:top_n]]
+        max_volume = max(0, top_n - len(trending))
+        vol_syms = [s for s,_ in fallback[:max_volume]]
+        out_syms: List[str] = []
+        out_syms.extend(trending)
+        for s in vol_syms:
+            if s not in out_syms:
+                out_syms.append(s)
+        out_syms = out_syms[:top_n]
         save_runtime_whitelist(out_syms)
         return out_syms
 
     rows.sort(key=lambda x: x[1], reverse=True)
-    out = [s for s,_,_ in rows[:top_n]]
+    max_volume = max(0, top_n - len(trending))
+    vol_syms = [s for s,_,_ in rows[:max_volume]]
+    out: List[str] = []
+    out.extend(trending)
+    for s in vol_syms:
+        if s not in out:
+            out.append(s)
+        if len(out) >= top_n:
+            break
     save_runtime_whitelist(out)
     return out


### PR DESCRIPTION
## Summary
- Read trending whitelist saved by trending feed and merge with volume scanner output, deduplicating and respecting limits.
- Allow configuring slots reserved for trending symbols via new `max_trending_symbols` option.

## Testing
- `pytest 2>&1 | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6899886b8eac832c9db10b15e07da2cf