### PR TITLE
Add optional ccxt REST backfill for CryptoFeedHub

### DIFF
--- a/autonomous_trader_scanner_trailing/config/config.json
+++ b/autonomous_trader_scanner_trailing/config/config.json
@@ -1,6 +1,7 @@
 {
   "exchange": "cryptofeed",
   "timeframe_crypto": "5m",
+  "enable_rest_history": false,
 
   "data_feeds": {
     "exchanges": ["KRAKEN"],


### PR DESCRIPTION
## Summary
- add `fetch_history` in `exchange_utils` using ccxt REST
- support optional REST OHLCV backfill in `CryptoFeedHub.ohlcv_df`
- gate REST calls behind new `enable_rest_history` config flag

## Testing
- `python -m py_compile utils/exchange_utils.py`
- `python -m py_compile utils/market_data_cryptofeed.py`


------
https://chatgpt.com/codex/tasks/task_e_68998a115d54832cb373015fa70b0ab7