### PR TITLE
Allow resetting paper trading balance

### DIFF
--- a/autonomous_trader_scanner_trailing/README.md
+++ b/autonomous_trader_scanner_trailing/README.md
@@ -1,0 +1,25 @@
+# Autonomous Trader
+
+## Resetting Paper Trading Balance
+
+To start a fresh paper-trading session:
+
+1. Delete the stored balance file:
+   ```bash
+   rm data/performance/balance.txt
+   ```
+   The next run will recreate it using the `dry_run_wallet` value.
+
+2. **Or** set the reset flag in the configuration. In `config/config.json`:
+   ```json
+   {
+     "risk": {
+       "reset_balance": true
+     }
+   }
+   ```
+   On startup the bot will ignore any existing balance and initialize the wallet
+   from `risk.dry_run_wallet`.
+
+After resetting, set `reset_balance` back to `false` if you want to persist the
+balance across runs.

--- a/autonomous_trader_scanner_trailing/config/config.json
+++ b/autonomous_trader_scanner_trailing/config/config.json
@@ -22,7 +22,8 @@
     "dry_run_wallet": 1000.0,
     "tradable_balance_ratio": 0.75,
     "stake_per_trade_ratio": 0.2,
-    "max_open_trades": 3
+    "max_open_trades": 3,
+    "reset_balance": false
   },
 
   "exits": {

--- a/autonomous_trader_scanner_trailing/utils/trade_executor.py
+++ b/autonomous_trader_scanner_trailing/utils/trade_executor.py
@@ -27,12 +27,14 @@ class PaperBroker:
 
     # ---------- persistence ----------
     def _load_balance(self) -> float:
+        risk_cfg = CFG.get("risk", {})
+        reset = risk_cfg.get("reset_balance", False) or CFG.get("reset_balance", False)
         try:
-            if os.path.exists(BAL_PATH):
+            if os.path.exists(BAL_PATH) and not reset:
                 return float(open(BAL_PATH, "r").read().strip())
         except Exception:
             pass
-        return CFG.get("dry_run_wallet", 1000.0)
+        return risk_cfg.get("dry_run_wallet", 1000.0)
 
     def _load_positions(self) -> Dict[str, Any]:
         try:


### PR DESCRIPTION
## Summary
- add `risk.reset_balance` flag to initialize the paper wallet from `dry_run_wallet`
- support resetting the balance when the stored file is missing or reset flag is set
- document how to start a fresh paper-trading session

## Testing
- `python -m py_compile utils/trade_executor.py`
- `python -m json.tool config/config.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6899927c5958832ca8ad805bdcf2029e