### PR TITLE
Improve risk management and symbol filtering

### DIFF
--- a/autonomous_trader/bot_runner.py
+++ b/autonomous_trader/bot_runner.py
@@ -46,9 +46,11 @@ def _scan_symbols(broker: PaperBroker, symbols: List[str]):
         sig = ai_combo_strategy.generate_signal(df, CFG)
         if sig.get("signal") == "BUY":
             price = float(df["close"].iloc[-1])
+            sl_pct = sig.get("sl_pct", exits_cfg.get("stop_loss_pct", 0.01))
+            tp_pct = sig.get("tp_pct", exits_cfg.get("take_profit_pct", 0.02))
             meta = {
-                "stop_loss_pct": exits_cfg.get("stop_loss_pct", 0.01),
-                "take_profit_pct": exits_cfg.get("take_profit_pct", 0.02),
+                "stop_loss_pct": sl_pct,
+                "take_profit_pct": tp_pct,
                 "breakeven_trigger_pct": trail_cfg.get("breakeven_pct", 0.005),
                 "trailing_stop_pct": trail_cfg.get("trail_pct", 0.006),
                 "score": sig.get("score"),

--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -2,6 +2,9 @@
 import os, json
 
 BASE = os.path.dirname(os.path.dirname(__file__))
+PERF_PATH = os.path.join(BASE, "data", "performance", "symbol_pnl.json")
+BLACKLIST = {"ZRO/USD", "STG/USD", "PUMP/USD", "LTC/USDT"}
+
 
 def load_crypto_whitelist():
     cfg = json.load(open(os.path.join(BASE, "config", "config.json"), "r"))
@@ -10,11 +13,23 @@ def load_crypto_whitelist():
     rt = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
     if os.path.exists(rt):
         try:
-            rw = json.load(open(rt,"r"))
+            rw = json.load(open(rt, "r"))
             if isinstance(rw, list) and rw:
                 wl = rw
         except Exception:
             pass
+
+    # remove statically blacklisted symbols
+    wl = [s for s in wl if s not in BLACKLIST]
+
+    # drop symbols with negative cumulative PnL
+    if os.path.exists(PERF_PATH):
+        try:
+            pnl = json.load(open(PERF_PATH, "r"))
+            wl = [s for s in wl if pnl.get(s, 0.0) >= 0.0]
+        except Exception:
+            pass
+
     return wl
 
 def save_runtime_whitelist(symbols):

--- a/tests/test_buy_defaults.py
+++ b/tests/test_buy_defaults.py
@@ -16,6 +16,8 @@ def test_buy_defaults_from_cfg(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_executor_main, "BAL_PATH", tmp_path / "balance.txt")
     monkeypatch.setattr(trade_executor_main, "POS_PATH", tmp_path / "positions.json")
     monkeypatch.setattr(trade_executor_main, "CD_PATH", tmp_path / "cooldowns.json")
+    monkeypatch.setattr(trade_executor_main, "PPL_PATH", tmp_path / "pnl.json")
+    monkeypatch.setattr(trade_executor_main, "TC_PATH", tmp_path / "tc.json")
 
     # deterministic risk parameters
     monkeypatch.setitem(trade_executor_main.RISK_CFG, "tradable_balance_ratio", 1.0)

--- a/tests/test_core_trade_executor.py
+++ b/tests/test_core_trade_executor.py
@@ -13,6 +13,8 @@ def _patch_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_executor, "BAL_PATH", tmp_path / "balance.txt")
     monkeypatch.setattr(trade_executor, "POS_PATH", tmp_path / "positions.json")
     monkeypatch.setattr(trade_executor, "CD_PATH", tmp_path / "cooldowns.json")
+    monkeypatch.setattr(trade_executor, "PPL_PATH", tmp_path / "pnl.json")
+    monkeypatch.setattr(trade_executor, "TC_PATH", tmp_path / "tc.json")
 
 
 def _setup_risk(monkeypatch):

--- a/tests/test_trade_flow.py
+++ b/tests/test_trade_flow.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 # dynamically load trade_executor module without package structure
-MODULE_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader_scanner_trailing" / "utils" / "trade_executor.py"
+MODULE_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader" / "utils" / "trade_executor.py"
 spec = importlib.util.spec_from_file_location("trade_executor", MODULE_PATH)
 trade_executor = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(trade_executor)
@@ -14,6 +14,8 @@ def test_trade_flow(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_executor, "BAL_PATH", tmp_path / "balance.txt")
     monkeypatch.setattr(trade_executor, "POS_PATH", tmp_path / "positions.json")
     monkeypatch.setattr(trade_executor, "CD_PATH", tmp_path / "cooldowns.json")
+    monkeypatch.setattr(trade_executor, "PPL_PATH", tmp_path / "pnl.json")
+    monkeypatch.setattr(trade_executor, "TC_PATH", tmp_path / "tc.json")
 
     # ensure deterministic risk configuration
     monkeypatch.setitem(trade_executor.RISK_CFG, "tradable_balance_ratio", 1.0)


### PR DESCRIPTION
## Summary
- add volume/ATR-aware signal generation with risk-reward targets
- filter losing symbols and blacklist poor performers when loading whitelist
- track per-symbol PnL, enforce daily trade limits, and adjust stake based on ATR

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689baee95318832c991a322d65c30c65