### PR TITLE
Use context managers for JSON loading

### DIFF
--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -7,13 +7,16 @@ BLACKLIST = {"ZRO/USD", "STG/USD", "PUMP/USD", "LTC/USDT"}
 
 
 def load_crypto_whitelist():
-    cfg = json.load(open(os.path.join(BASE, "config", "config.json"), "r"))
+    cfg_path = os.path.join(BASE, "config", "config.json")
+    with open(cfg_path, "r", encoding="utf-8") as f:
+        cfg = json.load(f)
     wl = cfg.get("whitelist", [])
     # overlay with runtime list if exists
     rt = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
     if os.path.exists(rt):
         try:
-            rw = json.load(open(rt, "r"))
+            with open(rt, "r", encoding="utf-8") as f:
+                rw = json.load(f)
             if isinstance(rw, list) and rw:
                 wl = rw
         except Exception:
@@ -25,7 +28,8 @@ def load_crypto_whitelist():
     # drop symbols with negative cumulative PnL
     if os.path.exists(PERF_PATH):
         try:
-            pnl = json.load(open(PERF_PATH, "r"))
+            with open(PERF_PATH, "r", encoding="utf-8") as f:
+                pnl = json.load(f)
             wl = [s for s in wl if pnl.get(s, 0.0) >= 0.0]
         except Exception:
             pass

--- a/autonomous_trader/utils/exchange_utils.py
+++ b/autonomous_trader/utils/exchange_utils.py
@@ -1,7 +1,9 @@
 # utils/exchange_utils.py
 import os, json
 BASE = os.path.dirname(os.path.dirname(__file__))
-CFG = json.load(open(os.path.join(BASE, "config", "config.json"), "r"))
+CFG_PATH = os.path.join(BASE, "config", "config.json")
+with open(CFG_PATH, "r", encoding="utf-8") as f:
+    CFG = json.load(f)
 
 # Lazy ccxt import only if needed
 _ccxt = None

--- a/autonomous_trader/utils/logger.py
+++ b/autonomous_trader/utils/logger.py
@@ -5,7 +5,9 @@ BASE = os.path.dirname(os.path.dirname(__file__))
 LOG_DIR = os.path.join(BASE, "data", "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
-CFG = json.load(open(os.path.join(BASE, "config", "config.json"), "r"))
+CFG_PATH = os.path.join(BASE, "config", "config.json")
+with open(CFG_PATH, "r", encoding="utf-8") as f:
+    CFG = json.load(f)
 
 class Notifier:
     def __init__(self, cfg):

--- a/autonomous_trader/utils/trade_executor.py
+++ b/autonomous_trader/utils/trade_executor.py
@@ -3,7 +3,9 @@ import os, json, time
 from typing import Dict, Any
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-CFG = json.load(open(os.path.join(BASE_DIR, "config", "config.json"), "r"))
+CFG_PATH = os.path.join(BASE_DIR, "config", "config.json")
+with open(CFG_PATH, "r", encoding="utf-8") as f:
+    CFG = json.load(f)
 RISK_CFG = CFG.get("risk", {})
 
 BAL_PATH = os.path.join(BASE_DIR, "data", "performance", "balance.txt")
@@ -46,7 +48,8 @@ class PaperBroker:
     def _load_positions(self) -> Dict[str, Any]:
         try:
             if os.path.exists(POS_PATH):
-                return json.load(open(POS_PATH, "r"))
+                with open(POS_PATH, "r", encoding="utf-8") as f:
+                    return json.load(f)
         except Exception:
             pass
         return {}
@@ -54,7 +57,8 @@ class PaperBroker:
     def _load_cooldowns(self) -> Dict[str, float]:
         try:
             if os.path.exists(CD_PATH):
-                return json.load(open(CD_PATH, "r"))
+                with open(CD_PATH, "r", encoding="utf-8") as f:
+                    return json.load(f)
         except Exception:
             pass
         return {}
@@ -62,7 +66,8 @@ class PaperBroker:
     def _load_symbol_pnl(self) -> Dict[str, float]:
         try:
             if os.path.exists(PPL_PATH):
-                return json.load(open(PPL_PATH, "r"))
+                with open(PPL_PATH, "r", encoding="utf-8") as f:
+                    return json.load(f)
         except Exception:
             pass
         return {}
@@ -71,7 +76,8 @@ class PaperBroker:
         today = time.strftime("%Y-%m-%d", time.gmtime())
         try:
             if os.path.exists(TC_PATH):
-                data = json.load(open(TC_PATH, "r"))
+                with open(TC_PATH, "r", encoding="utf-8") as f:
+                    data = json.load(f)
                 return data.get("count", 0), data.get("day", today)
         except Exception:
             pass

--- a/autonomous_trader/utils/trending_feed.py
+++ b/autonomous_trader/utils/trending_feed.py
@@ -33,7 +33,8 @@ def save_whitelist(symbols: List[str]) -> None:
 
 def _load_cfg():
     try:
-        return json.load(open(CFG_PATH, "r", encoding="utf-8"))
+        with open(CFG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
     except Exception:
         return {}
 


### PR DESCRIPTION
## Summary
- open config and runtime JSON files with context managers
- ensure all JSON reads use UTF-8 encoding in utility modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb8643f70832cb870bec23a23645e