### PR TITLE
Cache config for whitelist

### DIFF
--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -5,10 +5,17 @@ BASE = os.path.dirname(os.path.dirname(__file__))
 PERF_PATH = os.path.join(BASE, "data", "performance", "symbol_pnl.json")
 BLACKLIST = {"ZRO/USD", "STG/USD", "PUMP/USD", "LTC/USDT"}
 
+# Load configuration once at module import to avoid re-reading the file
+_CONFIG_PATH = os.path.join(BASE, "config", "config.json")
+try:
+    with open(_CONFIG_PATH, "r", encoding="utf-8") as _cfg_file:
+        _CONFIG = json.load(_cfg_file)
+except Exception:
+    _CONFIG = {}
+
 
 def load_crypto_whitelist():
-    cfg = json.load(open(os.path.join(BASE, "config", "config.json"), "r"))
-    wl = cfg.get("whitelist", [])
+    wl = _CONFIG.get("whitelist", [])
     # overlay with runtime list if exists
     rt = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
     if os.path.exists(rt):


### PR DESCRIPTION
## Summary
- Cache config.json at module import
- Use cached configuration in whitelist loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb86d5174832caea97e08ed964516