### PR TITLE
feat: tighten risk and prioritize profitable symbols

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -21,19 +21,24 @@
     "tradable_balance_ratio": 0.75,
     "stake_per_trade_ratio": 0.2,
     "max_open_trades": 3,
-    "reset_balance": false
+    "reset_balance": false,
+    "daily_loss_limit": 50
   },
 
   "exits": {
     "take_profit_pct": 0.02,
-    "stop_loss_pct": 0.01
+    "stop_loss_pct": 0.008
   },
 
   "trailing_stop": {
     "enable": true,
-    "activate_profit_pct": 0.004,
-    "breakeven_pct": 0.005,
-    "trail_pct": 0.006
+    "activate_profit_pct": 0.003,
+    "breakeven_pct": 0.004,
+    "trail_pct": 0.005
+  },
+
+  "strategy": {
+    "buy_score_threshold": 1.4
   },
 
   "logging": {

--- a/autonomous_trader/strategies/ai_combo_strategy.py
+++ b/autonomous_trader/strategies/ai_combo_strategy.py
@@ -90,7 +90,8 @@ def generate_signal(df: pd.DataFrame, cfg) -> dict:
 
     score = float(max(0.0, min(1.5, score)))
 
-    if trend_up and (macd_flip_up or breakout) and score >= 0.9:
+    min_score = cfg.get("strategy", {}).get("buy_score_threshold", 1.4)
+    if trend_up and (macd_flip_up or breakout) and score >= min_score:
         atr_pct = float(last["atr_pct"])
         risk_cfg = cfg.get("risk", {})
         atr_mult = risk_cfg.get("atr_stop_multiplier", 1.5)

--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -29,11 +29,12 @@ def load_crypto_whitelist():
     # remove statically blacklisted symbols
     wl = [s for s in wl if s not in BLACKLIST]
 
-    # drop symbols with negative cumulative PnL
+    # drop symbols with negative cumulative PnL and sort by performance
     if os.path.exists(PERF_PATH):
         try:
             pnl = json.load(open(PERF_PATH, "r"))
             wl = [s for s in wl if pnl.get(s, 0.0) >= 0.0]
+            wl.sort(key=lambda s: pnl.get(s, 0.0), reverse=True)
         except Exception:
             pass
 

--- a/tests/test_core_trade_executor.py
+++ b/tests/test_core_trade_executor.py
@@ -15,6 +15,7 @@ def _patch_paths(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_executor, "CD_PATH", tmp_path / "cooldowns.json")
     monkeypatch.setattr(trade_executor, "PPL_PATH", tmp_path / "pnl.json")
     monkeypatch.setattr(trade_executor, "TC_PATH", tmp_path / "tc.json")
+    monkeypatch.setattr(trade_executor, "DP_PATH", tmp_path / "dp.json")
 
 
 def _setup_risk(monkeypatch):
@@ -22,6 +23,7 @@ def _setup_risk(monkeypatch):
     monkeypatch.setitem(trade_executor.RISK_CFG, "stake_per_trade_ratio", 1.0)
     monkeypatch.setitem(trade_executor.RISK_CFG, "dry_run_wallet", 1000.0)
     monkeypatch.setitem(trade_executor.RISK_CFG, "reset_balance", False)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "daily_loss_limit", None)
 
 
 def test_trade_flow(tmp_path, monkeypatch):
@@ -33,7 +35,7 @@ def test_trade_flow(tmp_path, monkeypatch):
 
     symbol = "TEST"
     buy_price = 10.0
-    stake = broker.stake_amount()
+    stake = broker.stake_amount(symbol)
 
     buy_order = broker.buy(symbol, buy_price, {})
     assert buy_order is not None

--- a/tests/test_trade_flow.py
+++ b/tests/test_trade_flow.py
@@ -16,18 +16,20 @@ def test_trade_flow(tmp_path, monkeypatch):
     monkeypatch.setattr(trade_executor, "CD_PATH", tmp_path / "cooldowns.json")
     monkeypatch.setattr(trade_executor, "PPL_PATH", tmp_path / "pnl.json")
     monkeypatch.setattr(trade_executor, "TC_PATH", tmp_path / "tc.json")
+    monkeypatch.setattr(trade_executor, "DP_PATH", tmp_path / "dp.json")
 
     # ensure deterministic risk configuration
     monkeypatch.setitem(trade_executor.RISK_CFG, "tradable_balance_ratio", 1.0)
     monkeypatch.setitem(trade_executor.RISK_CFG, "stake_per_trade_ratio", 1.0)
     monkeypatch.setitem(trade_executor.RISK_CFG, "dry_run_wallet", 1000.0)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "daily_loss_limit", None)
 
     broker = trade_executor.PaperBroker()
     assert broker.balance == 1000.0
 
     symbol = "TEST"
     buy_price = 10.0
-    stake = broker.stake_amount()
+    stake = broker.stake_amount(symbol)
 
     # buy reduces balance and records position
     buy_order = broker.buy(symbol, buy_price, {})


### PR DESCRIPTION
## Summary
- raise strategy buy-score threshold and tighten exit config
- dynamically filter whitelist for profitable symbols and blacklist weak tokens
- add daily loss limits and profit-based position sizing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d39ab51bc832cbb55c12fa18d2df8