### PR TITLE
Add symbol loss limit check before buying

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -25,6 +25,8 @@
     "daily_loss_limit": 50
   },
 
+  "symbol_loss_limit": -3.0,
+
   "exits": {
     "take_profit_pct": 0.02,
     "stop_loss_pct": 0.008

--- a/autonomous_trader/utils/trade_executor.py
+++ b/autonomous_trader/utils/trade_executor.py
@@ -153,6 +153,14 @@ class PaperBroker:
     def buy(self, symbol: str, price: float, meta: Dict[str, Any]):
         if not self.can_open() or self._on_cooldown(symbol):
             return None
+
+        symbol_pnl = self.symbol_pnl.get(symbol, 0.0)
+        limit = CFG.get("symbol_loss_limit")
+        if limit is not None and symbol_pnl <= limit:
+            if CFG.get("debug", {}).get("verbose"):
+                print(f"[RISK] Skipping {symbol}: pnl {symbol_pnl:.2f} <= {limit:.2f}")
+            return None
+
         stake = self.stake_amount(symbol)
         if stake <= 0:
             return None

--- a/tests/test_core_trade_executor.py
+++ b/tests/test_core_trade_executor.py
@@ -67,3 +67,13 @@ def test_reset_balance(tmp_path, monkeypatch):
     trade_executor.RISK_CFG["reset_balance"] = True
     broker2 = trade_executor.PaperBroker()
     assert broker2.balance == pytest.approx(1000.0)
+
+
+def test_symbol_loss_limit(tmp_path, monkeypatch):
+    _patch_paths(tmp_path, monkeypatch)
+    _setup_risk(monkeypatch)
+    monkeypatch.setitem(trade_executor.CFG, "symbol_loss_limit", -3.0)
+
+    broker = trade_executor.PaperBroker()
+    broker.symbol_pnl["BAD"] = -4.0
+    assert broker.buy("BAD", 10.0, {}) is None


### PR DESCRIPTION
## Summary
- add per-symbol loss limit check in `PaperBroker.buy` to skip trading heavily losing symbols
- support new `symbol_loss_limit` setting in `config.json`
- test `PaperBroker` buy behavior when symbol loss exceeds limit

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dad1b8fa4832c8bb04dc0a2dcdb3b