### PR TITLE
Add script for updating trending whitelist

### DIFF
--- a/autonomous_trader/README.md
+++ b/autonomous_trader/README.md
@@ -48,3 +48,24 @@ positions lock in profit:
 
 When active, the bot trails the stop using `ATR * atr_trail_multiplier` from
 the position peak.
+
+## Updating the Trending Whitelist
+
+The bot can trade a dynamic universe of symbols derived from trending sources
+(CoinMarketCap, DEXTools and Reddit). To refresh this list outside the bot
+runtime, run:
+
+```bash
+python tools/update_trending_whitelist.py
+```
+
+This writes the combined symbols to `data/runtime/runtime_whitelist.json`,
+which `load_crypto_whitelist()` automatically reads on the next cycle. For
+continuous updates, schedule the script via cron, for example:
+
+```
+*/15 * * * * /usr/bin/python /path/to/tools/update_trending_whitelist.py
+```
+
+The main bot (`main.py` or `bot_runner.py`) already starts a background thread
+that performs the same refresh every few minutes when it is running.

--- a/autonomous_trader/tools/update_trending_whitelist.py
+++ b/autonomous_trader/tools/update_trending_whitelist.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Update runtime whitelist using combined trending sources.
+
+Fetches symbols from CoinMarketCap, DEXTools and Reddit via
+``fetch_all_trending_validated`` and writes them to
+``data/runtime/runtime_whitelist.json`` using ``save_whitelist``.
+
+This utility can be run manually or scheduled via cron to keep the bot's
+tradable universe fresh:
+
+    $ python tools/update_trending_whitelist.py
+
+Example cron entry to refresh every 15 minutes:
+
+    */15 * * * * /usr/bin/python /path/to/tools/update_trending_whitelist.py
+"""
+from utils.trending_feed import fetch_all_trending_validated, save_whitelist
+
+
+def main() -> None:
+    symbols = fetch_all_trending_validated()
+    if symbols:
+        save_whitelist(symbols)
+    else:
+        print("[TREND] No trending symbols found.")
+
+
+if __name__ == "__main__":
+    main()

--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -3,6 +3,7 @@ import os, json
 
 BASE = os.path.dirname(os.path.dirname(__file__))
 PERF_PATH = os.path.join(BASE, "data", "performance", "symbol_pnl.json")
+RUNTIME_PATH = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
 BLACKLIST = {"ZRO/USD", "STG/USD", "PUMP/USD", "LTC/USDT"}
 
 # Load configuration once at module import to avoid re-reading the file
@@ -17,10 +18,9 @@ except Exception:
 def load_crypto_whitelist():
     wl = _CONFIG.get("whitelist", [])
     # overlay with runtime list if exists
-    rt = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
-    if os.path.exists(rt):
+    if os.path.exists(RUNTIME_PATH):
         try:
-            rw = json.load(open(rt, "r"))
+            rw = json.load(open(RUNTIME_PATH, "r"))
             if isinstance(rw, list) and rw:
                 wl = rw
         except Exception:
@@ -41,6 +41,5 @@ def load_crypto_whitelist():
     return wl
 
 def save_runtime_whitelist(symbols):
-    path = os.path.join(BASE, "data", "runtime", "runtime_whitelist.json")
-    with open(path, "w", encoding="utf-8") as f:
+    with open(RUNTIME_PATH, "w", encoding="utf-8") as f:
         json.dump(symbols, f, indent=2)


### PR DESCRIPTION
## Summary
- add CLI tool `update_trending_whitelist.py` to fetch trending symbols and write to runtime whitelist
- document how to refresh trending whitelist manually or via cron
- centralize runtime whitelist path in `data_fetchers` for consistent loading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689db399bb1c832cb0dc91e05414f613