### PR TITLE
Add CSV OHLCV feed utility and test

### DIFF
--- a/autonomous_trader/utils/csv_ohlc_feed.py
+++ b/autonomous_trader/utils/csv_ohlc_feed.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import IO, Union
+
+import pandas as pd
+
+REQUIRED_COLUMNS = ["open", "high", "low", "close", "volume"]
+
+
+def read_csv_ohlcv(path: Union[str, Path, IO[str]]) -> pd.DataFrame:
+    """Read OHLCV bars from a CSV file and validate integrity.
+
+    Parameters
+    ----------
+    path:
+        Path to a CSV file or an opened file-like object. The CSV must
+        contain ``open``, ``high``, ``low``, ``close`` and ``volume``
+        columns. Optional timestamp columns such as ``timestamp`` or
+        ``date`` are used to ensure the data are ordered chronologically.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame containing only the required OHLCV columns sorted in
+        chronological order. The data types are coerced to ``float`` so the
+        frame can be fed directly into
+        :func:`strategies.ai_combo_strategy.generate_signal`.
+
+    Raises
+    ------
+    ValueError
+        If required columns are missing or if the data are not ordered
+        chronologically.
+
+    Examples
+    --------
+    Read a tiny CSV snippet and run the strategy.
+
+    >>> import io
+    >>> csv = io.StringIO("timestamp,open,high,low,close,volume\n0,1,2,0,1,10\n1,1,2,0,1,10")
+    >>> df = read_csv_ohlcv(csv)
+    >>> from strategies.ai_combo_strategy import generate_signal
+    >>> cfg = {'strategy': {'buy_score_threshold': 0.0}}
+    >>> generate_signal(df, cfg)['signal']
+    'HOLD'
+    """
+    df = pd.read_csv(path)
+
+    missing = [c for c in REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(f"missing required columns: {', '.join(missing)}")
+
+    time_col = next(
+        (c for c in ["timestamp", "time", "date", "datetime"] if c in df.columns),
+        None,
+    )
+    if time_col is not None:
+        ts = pd.to_datetime(df[time_col])
+        if not ts.is_monotonic_increasing:
+            raise ValueError("CSV rows must be in chronological order")
+        df = df.sort_values(time_col)
+
+    return df[REQUIRED_COLUMNS].astype(float).reset_index(drop=True)

--- a/tests/test_csv_ohlc_feed.py
+++ b/tests/test_csv_ohlc_feed.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# dynamically load modules so the package need not be installed
+UTIL_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader" / "utils" / "csv_ohlc_feed.py"
+spec = importlib.util.spec_from_file_location("csv_ohlc_feed", UTIL_PATH)
+csv_ohlc_feed = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(csv_ohlc_feed)
+read_csv_ohlcv = csv_ohlc_feed.read_csv_ohlcv
+
+STRAT_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader" / "strategies" / "ai_combo_strategy.py"
+spec2 = importlib.util.spec_from_file_location("ai_combo_strategy", STRAT_PATH)
+ai_combo_strategy = importlib.util.module_from_spec(spec2)
+spec2.loader.exec_module(ai_combo_strategy)
+generate_signal = ai_combo_strategy.generate_signal
+
+
+def _synth_data() -> pd.DataFrame:
+    """Create a dataset that triggers a BUY signal."""
+    n = 100
+    close = np.linspace(100, 150, n)
+    close[-1] = close[-2] + 5  # breakout on final bar
+    high = close + 1
+    low = close - 1
+    high[-1] = close[-1] - 1
+    low[-1] = close[-1] - 2
+    volume = np.ones(n) * 1000
+    volume[-1] = 1500
+    open_ = close.copy()
+    return pd.DataFrame({
+        "timestamp": np.arange(n),
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": volume,
+    })
+
+
+def test_generate_signal_from_csv(tmp_path):
+    df = _synth_data()
+    csv_file = tmp_path / "sample.csv"
+    df.to_csv(csv_file, index=False)
+
+    loaded = read_csv_ohlcv(csv_file)
+    cfg = {"strategy": {"buy_score_threshold": 0.0}}
+    signal = generate_signal(loaded, cfg)
+
+    assert signal["signal"] == "BUY"


### PR DESCRIPTION
## Summary
- add `read_csv_ohlcv` to load and validate OHLCV data from CSV
- demonstrate usage with doctest and unit test that triggers BUY signal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689db42a596c832c80f482b1e8c5f8a1