### PR TITLE
Adjust trailing stop and stop-loss thresholds

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -29,14 +29,14 @@
 
   "exits": {
     "take_profit_pct": 0.02,
-    "stop_loss_pct": 0.008
+    "stop_loss_pct": 0.015
   },
 
   "trailing_stop": {
     "enable": true,
-    "activate_profit_pct": 0.003,
+    "activate_profit_pct": 0.01,
     "breakeven_pct": 0.006,
-    "trail_pct": 0.01,
+    "trail_pct": 0.02,
     "atr_trail_multiplier": 1.0
   },
 


### PR DESCRIPTION
## Summary
- widen stop-loss and trailing stop percentages
- delay trailing stop activation to allow more profit before trailing

## Testing
- `pytest -q`
- `timeout 20s python autonomous_trader/main.py` *(fails: HTTPSConnectionPool(host='api.kraken.com', port=443): Max retries exceeded with url: /0/public/AssetPairs (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_689e6f3e676c832cb9c151504e60735c