### PR TITLE
Include quantity in sell trade logs

### DIFF
--- a/autonomous_trader/main.py
+++ b/autonomous_trader/main.py
@@ -215,7 +215,7 @@ def trading_loop():
                 if should_exit:
                     r = broker.sell(sym, price)
                     if r:
-                        log_trade("SELL", sym, 0, price, {"pnl": r["pnl"], "reason": reason})
+                        log_trade("SELL", sym, r["qty"], price, {"pnl": r["pnl"], "reason": reason})
                         n.send(f"SELL {sym} @ {price:.4f} | PnL: {r['pnl']:.2f} ({reason})")
                 continue
 

--- a/autonomous_trader/utils/trade_executor.py
+++ b/autonomous_trader/utils/trade_executor.py
@@ -241,12 +241,13 @@ class PaperBroker:
         pos = self.positions.get(symbol)
         if not pos:
             return None
-        proceeds = pos["qty"] * price
-        pnl = proceeds - pos["qty"] * pos["entry"]
+        qty = pos["qty"]
+        proceeds = qty * price
+        pnl = proceeds - qty * pos["entry"]
         self.balance += proceeds
         del self.positions[symbol]
         self.cooldowns[symbol] = self._now()
         self.symbol_pnl[symbol] = self.symbol_pnl.get(symbol, 0.0) + pnl
         self.daily_pnl += pnl
         self._persist_balance(); self._persist_positions(); self._persist_cooldowns(); self._persist_symbol_pnl(); self._persist_daily_pnl()
-        return {"symbol": symbol, "price": price, "pnl": pnl, "balance": self.balance}
+        return {"symbol": symbol, "qty": qty, "price": price, "pnl": pnl, "balance": self.balance}


### PR DESCRIPTION
## Summary
- Return executed quantity from `PaperBroker.sell`
- Log sold quantity instead of zero in `main.py`

## Testing
- `pytest -q`
- Ran a simulated buy/sell cycle and confirmed `data/logs/trades.csv` records non-zero sell quantities


------
https://chatgpt.com/codex/tasks/task_e_689e7024bf6c832cb7b7cd3ca743ad24