### PR TITLE
Centralize event logging

### DIFF
--- a/autonomous_trader/utils/logger.py
+++ b/autonomous_trader/utils/logger.py
@@ -37,11 +37,13 @@ class Notifier:
                 print("[WARN] Telegram send failed:", e)
 
 def log_trade(side: str, symbol: str, qty: float, price: float, extra=None):
+    """Record a trade in structured logs and stdout.
+
+    Event lines in ``events.log`` are handled solely by :meth:`Notifier.send`.
+    This helper writes trade details to ``trades.csv`` and prints to stdout.
+    """
     extra = extra or {}
     stamp = dt.datetime.utcnow().isoformat()
-    # events
-    with open(os.path.join(LOG_DIR, "events.log"), "a", encoding="utf-8") as f:
-        f.write(f"[{stamp} UTC] {side} {symbol} @ {price:.4f}\n")
     # trades.csv
     trades_path = os.path.join(LOG_DIR, "trades.csv")
     write_header = not os.path.exists(trades_path)

--- a/tests/test_event_logging.py
+++ b/tests/test_event_logging.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+
+def test_event_log_single_entry(tmp_path, monkeypatch):
+    module_path = Path(__file__).resolve().parents[1] / "autonomous_trader" / "utils" / "logger.py"
+    spec = importlib.util.spec_from_file_location("logger", module_path)
+    logger = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(logger)
+
+    # redirect log directory to temporary path
+    monkeypatch.setattr(logger, "LOG_DIR", tmp_path)
+
+    notifier = logger.Notifier({"telegram_enabled": False})
+
+    # first trade event
+    logger.log_trade("BUY", "TEST", 1.0, 10.0)
+    notifier.send("BUY TEST @ 10.00")
+
+    # second trade event
+    logger.log_trade("SELL", "TEST", 1.0, 12.0)
+    notifier.send("SELL TEST @ 12.00")
+
+    events_file = tmp_path / "events.log"
+    assert events_file.exists()
+    lines = events_file.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2


### PR DESCRIPTION
## Summary
- Log trade events only through `Notifier.send`
- Add test ensuring a single `events.log` line per trade

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e719efdbc832c8d7a4be9fb5de045