### PR TITLE
Add minimum price filter for scanner

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -13,6 +13,7 @@
     "refresh_minutes": 90,
     "min_24h_usdt_volume": 10000000,
     "min_atr_pct": 0.8,
+    "min_price_usd": 0.01,
     "max_symbols": 20
   },
 


### PR DESCRIPTION
## Summary
- add `min_price_usd` configuration option for the scanner
- skip symbols whose price is below the configured minimum when building whitelist

## Testing
- `pytest -q`
- `python - <<'PY'
import json, os, sys
sys.path.append('autonomous_trader')
from utils.scanner_helper import run_scanner
from utils.market_data_cryptofeed import register_global_hub

class FakeHub:
    def __init__(self):
        self.data = {
            'BTC/USDT': (30000, 1_000_000, 1.0),
            'DOGE/USDT': (0.15, 100_000_000, 1.0),
            'TINY/USDT': (0.0001, 100_000_000_000, 1.0),
        }
    def list_symbols(self):
        return list(self.data.keys())
    def snapshot(self, sym):
        info = self.data.get(sym)
        return (info[0], info[1]) if info else (None, None)
    def atr_pct(self, sym):
        info = self.data.get(sym)
        return info[2] if info else None

register_global_hub(FakeHub())
with open('autonomous_trader/config/config.json') as f:
    cfg = json.load(f)
# Set threshold to filter tiny priced tokens
cfg['scanner']['min_price_usd'] = 0.05
symbols = run_scanner(cfg)
print('Selected symbols:', symbols)
PY
- `cat autonomous_trader/data/runtime/runtime_whitelist.json`


------
https://chatgpt.com/codex/tasks/task_e_689e72b263e8832c8b1b5f1c0be283b7