### PR TITLE
Lower buy threshold for more frequent trades

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -2,12 +2,18 @@
   "exchange": "kraken",
   "market_data": "kraken_ws",
   "timeframe_crypto": "5m",
-
   "data_feeds": {
-    "channels": ["ticker", "trades"],
-    "symbols": ["XBT/USDT", "ETH/USDT", "SOL/USDT", "ADA/USDT"]
+    "channels": [
+      "ticker",
+      "trades"
+    ],
+    "symbols": [
+      "XBT/USDT",
+      "ETH/USDT",
+      "SOL/USDT",
+      "ADA/USDT"
+    ]
   },
-
   "scanner": {
     "enable": true,
     "refresh_minutes": 90,
@@ -16,7 +22,6 @@
     "min_price_usd": 0.01,
     "max_symbols": 20
   },
-
   "risk": {
     "dry_run_wallet": 1000.0,
     "tradable_balance_ratio": 0.75,
@@ -25,14 +30,11 @@
     "reset_balance": false,
     "daily_loss_limit": 50
   },
-
   "symbol_loss_limit": -3.0,
-
   "exits": {
     "take_profit_pct": 0.02,
     "stop_loss_pct": 0.015
   },
-
   "trailing_stop": {
     "enable": true,
     "activate_profit_pct": 0.01,
@@ -40,11 +42,9 @@
     "trail_pct": 0.02,
     "atr_trail_multiplier": 1.0
   },
-
   "strategy": {
-    "buy_score_threshold": 1.5
+    "buy_score_threshold": 1.0
   },
-
   "logging": {
     "print_status_every_sec": 30,
     "log_status_every_sec": 30


### PR DESCRIPTION
## Summary
- Reduce `buy_score_threshold` from 1.5 to 1.0 to trigger buys more often.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb1985120832c82e16566210ac47f