### PR TITLE
Log gate outcomes for HOLD signals

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -48,5 +48,8 @@
   "logging": {
     "print_status_every_sec": 30,
     "log_status_every_sec": 30
+  },
+  "debug": {
+    "verbose": false
   }
 }

--- a/autonomous_trader/main.py
+++ b/autonomous_trader/main.py
@@ -221,6 +221,7 @@ def trading_loop():
 
             if not df.empty and broker.can_open():
                 sig = generate_signal(df, CFG)
+                fail_gate = sig.get("failed")
 
                 # --- TEMP: simple momentum trigger so we can test entries
                 try:
@@ -237,9 +238,13 @@ def trading_loop():
                     if momo >= test_momo:
                         sig = {"signal": "BUY", "score": momo}
                     elif momo <= -test_momo:
-                        sig = {"signal": "HOLD", "score": momo}
+                        sig = {"signal": "HOLD", "score": momo, "failed": fail_gate}
+                    else:
+                        sig["failed"] = fail_gate
                 # --- END TEMP
 
+                if debug_verbose and sig.get("signal") == "HOLD":
+                    print(f"[HOLD] {sym} score={sig.get('score', 0):.2f} gate={sig.get('failed')}")
                 if debug_verbose:
                     print(f"[SIG] {sym} -> {sig}")
                 if sig.get("signal") == "BUY":


### PR DESCRIPTION
## Summary
- Track which entry gate failed inside `generate_signal`
- Report HOLD decisions with score and failed gate in the trading loop
- Add `debug.verbose` flag to configuration to toggle verbose logs

## Testing
- `pytest -q`
- `python - <<'PY'
import pandas as pd, json
from autonomous_trader.strategies.ai_combo_strategy import generate_signal
with open('autonomous_trader/config/config.json') as f:
    CFG = json.load(f)
CFG.setdefault('debug', {})['verbose'] = True
n=100
const_df = pd.DataFrame({'high':[100]*n,'low':[100]*n,'close':[100]*n,'volume':[1000]*n})
sig = generate_signal(const_df, CFG)
if CFG['debug']['verbose'] and sig.get('signal')=='HOLD':
    print(f"[HOLD] TEST score={sig.get('score',0):.2f} gate={sig.get('failed')}")
close=pd.Series(range(150,50,-1))[:100]
high=close+1
low=close-1
volume=[2000]*99+[4000]
trend_df=pd.DataFrame({'high':high,'low':low,'close':close,'volume':volume})
sig = generate_signal(trend_df, CFG)
if CFG['debug']['verbose'] and sig.get('signal')=='HOLD':
    print(f"[HOLD] TEST2 score={sig.get('score',0):.2f} gate={sig.get('failed')}")
PY`

------
https://chatgpt.com/codex/tasks/task_e_689eb468f2bc832cb565d1c89f248c8c