### PR TITLE
chore: raise buy score threshold

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -44,7 +44,7 @@
     "overrides": {}
   },
   "strategy": {
-    "buy_score_threshold": 1.0,
+    "buy_score_threshold": 1.3,
     "momentum_pct": 0.03
   },
   "logging": {

--- a/autonomous_trader/strategies/ai_combo_strategy.py
+++ b/autonomous_trader/strategies/ai_combo_strategy.py
@@ -90,7 +90,8 @@ def generate_signal(df: pd.DataFrame, cfg) -> dict:
 
     score = float(max(0.0, min(1.5, score)))
 
-    min_score = cfg.get("strategy", {}).get("buy_score_threshold", 1.5)
+    # Minimum score required to trigger a BUY; read from config to allow tuning
+    min_score = cfg.get("strategy", {}).get("buy_score_threshold", 1.3)
     if trend_up and (macd_flip_up or breakout) and score >= min_score:
         atr_pct = float(last["atr_pct"])
         risk_cfg = cfg.get("risk", {})


### PR DESCRIPTION
## Summary
- raise buy score threshold to 1.3 for stronger buy signals
- ensure AI combo strategy reads configurable threshold

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f84cf0b00832caa68650920de5593