### PR TITLE
Unify runtime whitelist updates

### DIFF
--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -41,5 +41,5 @@ def load_crypto_whitelist():
     return wl
 
 def save_runtime_whitelist(symbols):
-    with open(RUNTIME_PATH, "w", encoding="utf-8") as f:
-        json.dump(symbols, f, indent=2)
+    from .trending_feed import update_runtime_whitelist
+    update_runtime_whitelist(symbols)


### PR DESCRIPTION
## Summary
- add `update_runtime_whitelist` helper to atomically merge, dedupe and cap symbols
- switch scanner and trending feed to use unified runtime whitelist update
- proxy legacy `save_runtime_whitelist` through new updater

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8cecc8d8832cb4cf6e5056e20bd0