### PR TITLE
Raise buy score threshold to 1.5

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -46,7 +46,7 @@
     "overrides": {}
   },
   "strategy": {
-    "buy_score_threshold": 1.3,
+    "buy_score_threshold": 1.5,
     "momentum_pct": 0.03
   },
   "logging": {

--- a/autonomous_trader/strategies/ai_combo_strategy.py
+++ b/autonomous_trader/strategies/ai_combo_strategy.py
@@ -91,7 +91,7 @@ def generate_signal(df: pd.DataFrame, cfg) -> dict:
     score = float(max(0.0, min(1.5, score)))
 
     # Minimum score required to trigger a BUY; read from config to allow tuning
-    min_score = cfg.get("strategy", {}).get("buy_score_threshold", 1.3)
+    min_score = cfg.get("strategy", {}).get("buy_score_threshold", 1.5)
     if trend_up and (macd_flip_up or breakout) and score >= min_score:
         atr_pct = float(last["atr_pct"])
         risk_cfg = cfg.get("risk", {})


### PR DESCRIPTION
## Summary
- increase default buy score threshold to 1.5
- update AI combo strategy default min_score to match threshold

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fb4365b0832cb588d326f6006db4