### PR TITLE
Refine whitelist and PnL-driven staking

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -14,6 +14,12 @@
       "ADA/USDT"
     ]
   },
+  "whitelist": [
+    "MOON/USD",
+    "BIO/USD",
+    "SOL/USDT",
+    "ADA/USDT"
+  ],
   "scanner": {
     "enable": true,
     "refresh_minutes": 90,
@@ -30,9 +36,12 @@
     "reset_balance": false,
     "daily_loss_limit": 30,
     "fee_pct": 0.0,
-    "slippage_pct": 0.0
+    "slippage_pct": 0.0,
+    "positive_pnl_stake_multiplier": 1.5,
+    "negative_pnl_stake_multiplier": 0.5
   },
   "symbol_loss_limit": -2.0,
+  "whitelist_min_pnl": -1.0,
   "exits": {
     "take_profit_pct": 0.025,
     "stop_loss_pct": 0.02

--- a/autonomous_trader/utils/data_fetchers.py
+++ b/autonomous_trader/utils/data_fetchers.py
@@ -17,6 +17,8 @@ except Exception:
 
 def load_crypto_whitelist():
     wl = _CONFIG.get("whitelist", [])
+    pnl_threshold = _CONFIG.get("whitelist_min_pnl", -1.0)
+
     # overlay with runtime list if exists
     if os.path.exists(RUNTIME_PATH):
         try:
@@ -29,11 +31,11 @@ def load_crypto_whitelist():
     # remove statically blacklisted symbols
     wl = [s for s in wl if s not in BLACKLIST]
 
-    # drop symbols with negative cumulative PnL and sort by performance
+    # drop symbols performing below threshold and sort by performance
     if os.path.exists(PERF_PATH):
         try:
             pnl = json.load(open(PERF_PATH, "r"))
-            wl = [s for s in wl if pnl.get(s, 0.0) >= 0.0]
+            wl = [s for s in wl if pnl.get(s, 0.0) >= pnl_threshold]
             wl.sort(key=lambda s: pnl.get(s, 0.0), reverse=True)
         except Exception:
             pass

--- a/autonomous_trader/utils/trade_executor.py
+++ b/autonomous_trader/utils/trade_executor.py
@@ -22,6 +22,8 @@ except Exception:  # pragma: no cover
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 CFG = json.load(open(os.path.join(BASE_DIR, "config", "config.json"), "r"))
 RISK_CFG = CFG.get("risk", {})
+POS_PNL_MULT = RISK_CFG.get("positive_pnl_stake_multiplier", 1.5)
+NEG_PNL_MULT = RISK_CFG.get("negative_pnl_stake_multiplier", 0.5)
 
 BAL_PATH = os.path.join(BASE_DIR, "data", "performance", "balance.txt")
 POS_PATH = os.path.join(BASE_DIR, "data", "performance", "positions.json")
@@ -172,9 +174,9 @@ class PaperBroker:
         if symbol:
             pnl = self.symbol_pnl.get(symbol, 0.0)
             if pnl > 0:
-                stake *= 1.5
+                stake *= POS_PNL_MULT
             elif pnl < 0:
-                stake *= 0.5
+                stake *= NEG_PNL_MULT
         return min(stake, self.balance)
 
     # ---------- trading ----------


### PR DESCRIPTION
## Summary
- narrow default whitelist to a focused set of strong symbols
- drop or deprioritize symbols whose cumulative PnL falls below a configurable threshold
- scale stake sizes using configurable multipliers based on recent symbol performance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fb2cdc4c832caf9018c910d04174