### PR TITLE
feat: add strategy filters

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -56,7 +56,14 @@
   },
   "strategy": {
     "buy_score_threshold": 1.5,
-    "momentum_pct": 0.03
+    "momentum_pct": 0.03,
+    "filters": {
+      "avg_volume_period": 20,
+      "min_avg_volume": 0,
+      "max_atr_pct": 0.06,
+      "adx_period": 14,
+      "min_adx": 0
+    }
   },
   "logging": {
     "print_status_every_sec": 30,

--- a/tests/test_ai_combo_strategy.py
+++ b/tests/test_ai_combo_strategy.py
@@ -36,3 +36,29 @@ def test_buy_score_threshold_respected():
 
     assert ai_combo_strategy.generate_signal(df, high_cfg)["signal"] == "HOLD"
     assert ai_combo_strategy.generate_signal(df, low_cfg)["signal"] == "BUY"
+
+
+def test_min_avg_volume_filter():
+    df = _synth_data()
+    cfg = {"strategy": {"filters": {"avg_volume_period": 20, "min_avg_volume": 2000}}}
+    res = ai_combo_strategy.generate_signal(df, cfg)
+    assert res["signal"] == "HOLD"
+    assert res.get("failed") == "avg_volume"
+
+
+def test_atr_ceiling_filter():
+    df = _synth_data()
+    df["high"] = df["close"] * 1.2
+    df["low"] = df["close"] * 0.8
+    cfg = {"strategy": {"filters": {"max_atr_pct": 0.01}}}
+    res = ai_combo_strategy.generate_signal(df, cfg)
+    assert res["signal"] == "HOLD"
+    assert res.get("failed") == "atr_range"
+
+
+def test_adx_filter():
+    df = _synth_data()
+    cfg = {"strategy": {"filters": {"adx_period": 14, "min_adx": 101}}}
+    res = ai_combo_strategy.generate_signal(df, cfg)
+    assert res["signal"] == "HOLD"
+    assert res.get("failed") == "adx"


### PR DESCRIPTION
## Summary
- allow strategy to enforce minimum average volume, ATR% ceiling, and optional ADX trend-strength requirement
- expose these knobs in config under `strategy.filters`
- test new filters for volume, volatility ceiling, and ADX

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fc9d0d14832cb17529330248fa94