### PR TITLE
Track rolling symbol expectancy and enforce whitelist filtering

### DIFF
--- a/autonomous_trader/tools/reconcile_equity.py
+++ b/autonomous_trader/tools/reconcile_equity.py
@@ -13,7 +13,7 @@ Example cron entry to run daily at midnight (UTC):
 import os
 import json
 import sys
-from typing import Dict
+from typing import Dict, Any
 
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -36,7 +36,7 @@ def _read_balance() -> float:
         return 0.0
 
 
-def _read_symbol_pnl() -> Dict[str, float]:
+def _read_symbol_pnl() -> Dict[str, Any]:
     try:
         with open(PNL_PATH, "r", encoding="utf-8") as f:
             return json.load(f)
@@ -51,7 +51,15 @@ def reconcile() -> None:
 
     balance = _read_balance()
     pnl_map = _read_symbol_pnl()
-    total_pnl = sum(float(v) for v in pnl_map.values())
+    total_pnl = 0.0
+    for v in pnl_map.values():
+        if isinstance(v, list):
+            total_pnl += sum(v)
+        else:
+            try:
+                total_pnl += float(v)
+            except Exception:
+                continue
     expected = start + total_pnl
     diff = balance - expected
 

--- a/tests/test_core_trade_executor.py
+++ b/tests/test_core_trade_executor.py
@@ -75,7 +75,7 @@ def test_symbol_loss_limit(tmp_path, monkeypatch):
     monkeypatch.setitem(trade_executor.CFG, "symbol_loss_limit", -3.0)
 
     broker = trade_executor.PaperBroker()
-    broker.symbol_pnl["BAD"] = -4.0
+    broker.symbol_pnl["BAD"] = [-4.0]
     assert broker.buy("BAD", 10.0, {}) is None
 
 

--- a/tests/test_expectancy.py
+++ b/tests/test_expectancy.py
@@ -1,0 +1,57 @@
+import importlib.util
+from pathlib import Path
+import json
+import pytest
+
+# load trade_executor
+TE_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader" / "utils" / "trade_executor.py"
+spec_te = importlib.util.spec_from_file_location("trade_executor", TE_PATH)
+trade_executor = importlib.util.module_from_spec(spec_te)
+spec_te.loader.exec_module(trade_executor)
+
+# load data_fetchers
+DF_PATH = Path(__file__).resolve().parents[1] / "autonomous_trader" / "utils" / "data_fetchers.py"
+spec_df = importlib.util.spec_from_file_location("data_fetchers", DF_PATH)
+data_fetchers = importlib.util.module_from_spec(spec_df)
+spec_df.loader.exec_module(data_fetchers)
+
+
+def _patch_trade_paths(tmp_path, monkeypatch):
+    monkeypatch.setattr(trade_executor, "BAL_PATH", tmp_path / "balance.txt")
+    monkeypatch.setattr(trade_executor, "POS_PATH", tmp_path / "positions.json")
+    monkeypatch.setattr(trade_executor, "CD_PATH", tmp_path / "cooldowns.json")
+    monkeypatch.setattr(trade_executor, "PPL_PATH", tmp_path / "pnl.json")
+    monkeypatch.setattr(trade_executor, "TC_PATH", tmp_path / "tc.json")
+    monkeypatch.setattr(trade_executor, "DP_PATH", tmp_path / "dp.json")
+
+
+def _setup_risk(monkeypatch):
+    monkeypatch.setitem(trade_executor.RISK_CFG, "tradable_balance_ratio", 1.0)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "stake_per_trade_ratio", 0.1)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "dry_run_wallet", 1000.0)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "max_trades_per_day", 100)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "cooldown_minutes", 0)
+    monkeypatch.setitem(trade_executor.RISK_CFG, "daily_loss_limit", None)
+
+
+def test_symbol_pnl_rolling_window(tmp_path, monkeypatch):
+    _patch_trade_paths(tmp_path, monkeypatch)
+    _setup_risk(monkeypatch)
+    broker = trade_executor.PaperBroker()
+    for _ in range(trade_executor.EXPECTANCY_WINDOW + 5):
+        broker.buy("AAA", 10.0, {})
+        broker.sell("AAA", 11.0)
+    assert len(broker.symbol_pnl["AAA"]) == trade_executor.EXPECTANCY_WINDOW
+
+
+def test_whitelist_drops_negative_expectancy(tmp_path, monkeypatch):
+    perf_path = tmp_path / "symbol_pnl.json"
+    perf_path.write_text(json.dumps({"GOOD": [1, -0.5, 2], "BAD": [-1, -1, -1]}))
+
+    monkeypatch.setattr(data_fetchers, "PERF_PATH", perf_path)
+    monkeypatch.setattr(data_fetchers, "RUNTIME_PATH", tmp_path / "runtime.json")
+    monkeypatch.setattr(data_fetchers, "_CONFIG", {"whitelist": ["GOOD", "BAD"]})
+
+    wl = data_fetchers.load_crypto_whitelist()
+    assert "GOOD" in wl
+    assert "BAD" not in wl

--- a/tests/test_symbol_loss_limit.py
+++ b/tests/test_symbol_loss_limit.py
@@ -41,7 +41,7 @@ def test_symbol_loss_limit_removes_from_whitelist(tmp_path, monkeypatch):
     broker.buy("BAD", 10.0, {})
     broker.sell("BAD", 0.0)
 
-    assert broker.symbol_pnl["BAD"] == pytest.approx(-500.0)
+    assert sum(broker.symbol_pnl["BAD"]) == pytest.approx(-500.0)
 
     wl_before = json.loads(rw_path.read_text())
     assert "BAD" in wl_before


### PR DESCRIPTION
## Summary
- Track rolling PnL history per symbol with a configurable 30‑trade window and update `symbol_pnl.json` on each trade close.
- Drop symbols with negative expectancy from the crypto whitelist and sort remaining symbols by expectancy.
- Support list-based PnL records in equity reconciliation and add tests for expectancy window and whitelist pruning.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fef42424832cbfe08ac563c76a64