### PR TITLE
Adjust AI combo threshold

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -56,7 +56,7 @@
     "overrides": {}
   },
   "strategy": {
-    "buy_score_threshold": 1.5,
+    "buy_score_threshold": 1.1,
     "momentum_pct": 0.03,
     "filters": {
       "avg_volume_period": 20,


### PR DESCRIPTION
## Summary
- reduce AI combo strategy `buy_score_threshold` to 1.1 so typical setups can trigger

## Testing
- `pytest -q`
- Ran AI combo strategy over sample historical OHLC data to confirm BUY signals appear

------
https://chatgpt.com/codex/tasks/task_e_68ab6bb417dc832cb6bc0bb354600e05