### PR TITLE
Allow ATR filter tuning via environment variable

### DIFF
--- a/autonomous_trader/config/config.json
+++ b/autonomous_trader/config/config.json
@@ -24,7 +24,7 @@
     "enable": true,
     "refresh_minutes": 90,
     "min_24h_usdt_volume": 10000000,
-    "min_atr_pct": 0.8,
+    "min_atr_pct": 0.008,
     "min_price_usd": 0.01,
     "max_symbols": 20
   },

--- a/autonomous_trader/utils/scanner_helper.py
+++ b/autonomous_trader/utils/scanner_helper.py
@@ -1,4 +1,5 @@
 # utils/scanner_helper.py
+import os
 from typing import List, Tuple
 from utils.trending_feed import update_runtime_whitelist
 from utils.market_data_cryptofeed import get_global_hub
@@ -26,6 +27,13 @@ def run_scanner(cfg) -> List[str]:
         return []
     min_qv = float(sc.get("min_24h_usdt_volume", 10_000_000))
     min_atr_pct = float(sc.get("min_atr_pct", 0.8))
+    # Allow runtime override via environment variable
+    env_min_atr = os.getenv("SCANNER_MIN_ATR_PCT")
+    if env_min_atr:
+        try:
+            min_atr_pct = float(env_min_atr)
+        except ValueError:
+            pass
     min_price = float(sc.get("min_price_usd", 0.0))
 
     rows: List[Tuple[str, float, float]] = []  # (symbol, qv_usd, atr_pct)


### PR DESCRIPTION
## Summary
- lower scanner ATR floor to 0.8%
- allow overriding ATR floor with `SCANNER_MIN_ATR_PCT` env variable

## Testing
- `pytest`
- `SCANNER_MIN_ATR_PCT=0.02 python - <<'PY' ...` (scanner run)


------
https://chatgpt.com/codex/tasks/task_e_68ab6d5d28a4832cb10f6b5ca9ada2f7